### PR TITLE
Fix config name, use m64p messaging API

### DIFF
--- a/plugin-mupen64plus/gfx_m64p.c
+++ b/plugin-mupen64plus/gfx_m64p.c
@@ -45,8 +45,8 @@ static ptr_ConfigGetParamBool     ConfigGetParamBool = NULL;
 
 static bool warn_hle;
 static bool plugin_initialized;
-static void (*debug_callback)(void *, int, const char *);
-static void *debug_call_context;
+void (*debug_callback)(void *, int, const char *);
+void *debug_call_context;
 static struct core_config config;
 
 m64p_dynlib_handle CoreLibHandle;
@@ -80,7 +80,7 @@ EXPORT m64p_error CALL PluginStartup(m64p_dynlib_handle _CoreLibHandle, void *Co
     ConfigGetParamBool = (ptr_ConfigGetParamBool)DLSYM(CoreLibHandle, "ConfigGetParamBool");
 
     ConfigOpenSection("Video-General", &configVideoGeneral);
-    ConfigOpenSection("Video-AngrylionPlus", &configVideoAngrylionPlus);
+    ConfigOpenSection("Video-Angrylion-Plus", &configVideoAngrylionPlus);
 
     ConfigSetDefaultBool(configVideoGeneral, "Fullscreen", 0, "Use fullscreen mode if True, or windowed mode if False");
     ConfigSetDefaultInt(configVideoGeneral, "ScreenWidth", 640, "Width of output window or fullscreen width");
@@ -91,7 +91,7 @@ EXPORT m64p_error CALL PluginStartup(m64p_dynlib_handle _CoreLibHandle, void *Co
     ConfigSetDefaultBool(configVideoAngrylionPlus, "AnamorphicWidescreen", 0, "Use anamorphic 16:9 output mode if True");
 
     ConfigSaveSection("Video-General");
-    ConfigSaveSection("Video-AngrylionPlus");
+    ConfigSaveSection("Video-Angrylion-Plus");
 
     plugin_initialized = true;
     return M64ERR_SUCCESS;

--- a/plugin-mupen64plus/gfx_m64p.h
+++ b/plugin-mupen64plus/gfx_m64p.h
@@ -13,3 +13,5 @@
 extern GFX_INFO gfx;
 extern m64p_dynlib_handle CoreLibHandle;
 extern void(*render_callback)(int);
+extern void (*debug_callback)(void *, int, const char *);
+extern void *debug_call_context;

--- a/plugin-mupen64plus/msg.c
+++ b/plugin-mupen64plus/msg.c
@@ -1,5 +1,6 @@
 #include "core/msg.h"
 #include "core/version.h"
+#include "gfx_m64p.h"
 
 #include <stdarg.h>
 #include <stdio.h>
@@ -9,38 +10,46 @@
 
 void msg_error(const char * err, ...)
 {
-    printf(CORE_SIMPLE_NAME "-error: ");
+    if (debug_callback == NULL)
+        return;
 
     va_list arg;
     va_start(arg, err);
-    vprintf(err, arg);
+    char buf[MSG_BUFFER_LEN];
+    vsprintf(buf, err, arg);
+
+    (*debug_callback)(debug_call_context, M64MSG_ERROR, buf);
+
     va_end(arg);
-
-    printf("\n");
-
     exit(0);
 }
 
 void msg_warning(const char* err, ...)
 {
-    printf(CORE_SIMPLE_NAME "-warning: ");
+    if (debug_callback == NULL)
+        return;
 
     va_list arg;
     va_start(arg, err);
-    vprintf(err, arg);
-    va_end(arg);
+    char buf[MSG_BUFFER_LEN];
+    vsprintf(buf, err, arg);
 
-    printf("\n");
+    (*debug_callback)(debug_call_context, M64MSG_WARNING, buf);
+
+    va_end(arg);
 }
 
 void msg_debug(const char* err, ...)
 {
-    printf(CORE_SIMPLE_NAME "-debug: ");
+    if (debug_callback == NULL)
+        return;
 
     va_list arg;
     va_start(arg, err);
-    vprintf(err, arg);
-    va_end(arg);
+    char buf[MSG_BUFFER_LEN];
+    vsprintf(buf, err, arg);
 
-    printf("\n");
+    (*debug_callback)(debug_call_context, M64MSG_VERBOSE, buf);
+
+    va_end(arg);
 }


### PR DESCRIPTION
The name written in the config file needs to match how it looks elsewhere so that frontends can know where to look (I added the -).

Also, since msg.c is unique to mupen64plus now, we can use the built-in API for messaging instead of printf. Some mupen64plus GUI's have log viewers to capture the messages.