### PR TITLE
Add support for checking RDRAM size through mupen64plus API

### DIFF
--- a/plugin-mupen64plus/api/m64p_common.h
+++ b/plugin-mupen64plus/api/m64p_common.h
@@ -1,0 +1,90 @@
+/* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * *
+ *   Mupen64plus-core - m64p_common.h                                      *
+ *   Mupen64Plus homepage: http://code.google.com/p/mupen64plus/           *
+ *   Copyright (C) 2009 Richard Goedeken                                   *
+ *                                                                         *
+ *   This program is free software; you can redistribute it and/or modify  *
+ *   it under the terms of the GNU General Public License as published by  *
+ *   the Free Software Foundation; either version 2 of the License, or     *
+ *   (at your option) any later version.                                   *
+ *                                                                         *
+ *   This program is distributed in the hope that it will be useful,       *
+ *   but WITHOUT ANY WARRANTY; without even the implied warranty of        *
+ *   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the         *
+ *   GNU General Public License for more details.                          *
+ *                                                                         *
+ *   You should have received a copy of the GNU General Public License     *
+ *   along with this program; if not, write to the                         *
+ *   Free Software Foundation, Inc.,                                       *
+ *   51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.          *
+ * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
+
+/* This header file defines typedefs for function pointers to common Core
+ * and plugin functions, for use by the front-end and plugin modules to attach
+ * to the dynamic libraries.
+ */
+
+#if !defined(M64P_COMMON_H)
+#define M64P_COMMON_H
+
+#include "m64p_types.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/* PluginGetVersion()
+ *
+ * This function retrieves version information from a library. This
+ * function is the same for the core library and the plugins.
+ */
+typedef m64p_error (*ptr_PluginGetVersion)(m64p_plugin_type *, int *, int *, const char **, int *);
+#if defined(M64P_PLUGIN_PROTOTYPES) || defined(M64P_CORE_PROTOTYPES)
+EXPORT m64p_error CALL PluginGetVersion(m64p_plugin_type *, int *, int *, const char **, int *);
+#endif
+
+/* CoreGetAPIVersions()
+ *
+ * This function retrieves API version information from the core.
+ */
+typedef m64p_error (*ptr_CoreGetAPIVersions)(int *, int *, int *, int *);
+#if defined(M64P_CORE_PROTOTYPES)
+EXPORT m64p_error CALL CoreGetAPIVersions(int *, int *, int *, int *);
+#endif
+
+/* CoreErrorMessage()
+ *
+ * This function returns a pointer to a NULL-terminated string giving a
+ * human-readable description of the error.
+*/
+typedef const char * (*ptr_CoreErrorMessage)(m64p_error);
+#if defined(M64P_CORE_PROTOTYPES)
+EXPORT const char * CALL CoreErrorMessage(m64p_error);
+#endif
+
+/* PluginStartup()
+ *
+ * This function initializes a plugin for use by allocating memory, creating
+ * data structures, and loading the configuration data.
+*/
+typedef m64p_error (*ptr_PluginStartup)(m64p_dynlib_handle, void *, void (*)(void *, int, const char *));
+#if defined(M64P_PLUGIN_PROTOTYPES) || defined(M64P_CORE_PROTOTYPES)
+EXPORT m64p_error CALL PluginStartup(m64p_dynlib_handle, void *, void (*)(void *, int, const char *));
+#endif
+
+/* PluginShutdown()
+ *
+ * This function destroys data structures and releases memory allocated by
+ * the plugin library.
+*/
+typedef m64p_error (*ptr_PluginShutdown)(void);
+#if defined(M64P_PLUGIN_PROTOTYPES) || defined(M64P_CORE_PROTOTYPES)
+EXPORT m64p_error CALL PluginShutdown(void);
+#endif
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* #define M64P_COMMON_H */
+

--- a/plugin-mupen64plus/api/m64p_plugin.h
+++ b/plugin-mupen64plus/api/m64p_plugin.h
@@ -103,6 +103,19 @@ typedef struct {
     unsigned int * VI_Y_SCALE_REG;
 
     void (*CheckInterrupts)(void);
+
+    /* The GFX_INFO.version parameter was added in version 2.5.1 of the core.
+       Plugins should ensure the core is at least this version before
+       attempting to read GFX_INFO.version. */
+    unsigned int version;
+    /* SP_STATUS_REG and RDRAM_SIZE were added in version 2 of GFX_INFO.version.
+       Plugins should only attempt to read these values if GFX_INFO.version is at least 2. */
+
+    /* The RSP plugin should set (HALT | BROKE | TASKDONE) *before* calling ProcessDList.
+       It should not modify SP_STATUS_REG after ProcessDList has returned.
+       This will allow the GFX plugin to unset these bits if it needs. */
+    unsigned int * SP_STATUS_REG;
+    const unsigned int * RDRAM_SIZE;
 } GFX_INFO;
 
 typedef struct {

--- a/plugin-mupen64plus/gfx_m64p.h
+++ b/plugin-mupen64plus/gfx_m64p.h
@@ -2,6 +2,7 @@
 
 #include "core/core.h"
 #include "api/m64p_plugin.h"
+#include "api/m64p_common.h"
 
 #ifdef _WIN32
 #define DLSYM(a, b) GetProcAddress(a, b)

--- a/plugin-mupen64plus/plugin.c
+++ b/plugin-mupen64plus/plugin.c
@@ -10,12 +10,20 @@
 
 static uint32_t rdram_size;
 static uint8_t* rdram_hidden_bits;
+static ptr_PluginGetVersion CoreGetVersion = NULL;
 
 void plugin_init(void)
 {
-    rdram_size = 0x800000;
+    CoreGetVersion = (ptr_PluginGetVersion) DLSYM(CoreLibHandle, "PluginGetVersion");
 
-    // Zilmar plugins also can't access the hidden bits, so allocate it on our own
+    int core_version;
+    CoreGetVersion(NULL, &core_version, NULL, NULL, NULL);
+    if (core_version >= 0x020501)
+        rdram_size = *gfx.RDRAM_SIZE;
+    else
+        rdram_size = 0x800000;
+
+    // mupen64plus plugins can't access the hidden bits, so allocate it on our own
     rdram_hidden_bits = malloc(rdram_size);
     memset(rdram_hidden_bits, 3, rdram_size);
 }


### PR DESCRIPTION
Recent versions of the mupen64plus support checking the RDRAM size via the API