### PR TITLE
Set PATH_CORE before it's needed

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -27,6 +27,10 @@ find_package(Git REQUIRED)
 find_package(PythonInterp 3.2 REQUIRED)
 find_package(OpenGL REQUIRED)
 
+# RDP core library and shared plugin library
+set(PATH_CORE "core")
+set(PATH_PLUGIN_COMMON "plugin-common")
+
 # run script to generate version.h
 set(PATH_VERSION_IN "${PATH_CORE}/version.h.in")
 set(PATH_VERSION_OUT "${PATH_CORE}/version.h")
@@ -40,10 +44,6 @@ add_custom_command(
         "${CMAKE_SOURCE_DIR}/${PATH_VERSION_OUT}"
     COMMENT "Generate Git version"
 )
-
-# RDP core library and shared plugin library
-set(PATH_CORE "core")
-set(PATH_PLUGIN_COMMON "plugin-common")
 
 file(GLOB SOURCES_CORE "${PATH_CORE}/*.c" "${PATH_CORE}/*.cpp")
 file(GLOB SOURCES_PLUGIN_COMMON "${PATH_PLUGIN_COMMON}/*.c")

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2,6 +2,8 @@ cmake_minimum_required(VERSION 2.8)
 
 option(RETRACER "Set to ON to build the retracer tool" ${RETRACER})
 
+project(angrylion-plus)
+
 # check for INTERPROCEDURAL_OPTIMIZATION support
 if((${CMAKE_VERSION} VERSION_EQUAL 3.9) OR (${CMAKE_VERSION} VERSION_GREATER 3.9))
     cmake_policy(SET CMP0069 NEW)
@@ -12,8 +14,6 @@ if((${CMAKE_VERSION} VERSION_EQUAL 3.9) OR (${CMAKE_VERSION} VERSION_GREATER 3.9
         message("Interprocedural optimizations enabled")
     endif(ENABLE_IPO)
 endif()
-
-project(angrylion-plus)
 
 # C++14 is required for the Parallel utility class
 set(CMAKE_CXX_STANDARD 14)


### PR DESCRIPTION
PATH_CORE is used to generate version.h, build is failing right now because these items are in the wrong order