### PR TITLE
Only apply fix for non-filtered mode

### DIFF
--- a/core/rdp/vi.c
+++ b/core/rdp/vi.c
@@ -718,9 +718,9 @@ void rdp_update_vi(void)
 
     hres =  h_end - h_start;
     vres = (v_end - v_start) >> 1; // vertical is measured in half-lines
-    
+
     // skip invalid/unsupported frame sizes
-    if (hres <= 0 || vres <= 0) {
+    if (vi_mode != VI_MODE_NORMAL && (hres <= 0 || vres <= 0)) {
        return;
     }
 


### PR DESCRIPTION
This might be a bit wordy..

Perfect Dark (and other Rare games), use the DPC_STATUS_FREEZE bit. Emulators can't really handle this well, and hacks are in place to work around it. This bit is why some Rare games (Blast Corps, DK64), don't work properly in the latest PJ64 + this plugin for instance.

I am trying to emulate this bit more accurately. You can see the commit I am working on here if you're interested: https://github.com/loganmc10/mupen64plus-core/commit/bbbaa26448d613b4e6c64979294807396bf817ef

Anyway, after that commit, the logos in Perfect Dark shake when using filtered mode. Unfiltered mode is fine. Removing this check for filtered mode fixes the shaking, since filtered mode was never affected, I think this is safe to apply for both PJ64 and mupen64plus.