### PR TITLE
Don't unset FREEZE bit

### DIFF
--- a/core/rdp/cmd.c
+++ b/core/rdp/cmd.c
@@ -229,7 +229,7 @@ void rdp_update(void)
     uint32_t dp_current_al = *dp_reg[DP_CURRENT] & ~7;
     uint32_t dp_end_al = *dp_reg[DP_END] & ~7;
 
-    *dp_reg[DP_STATUS] &= ~DP_STATUS_FREEZE;
+//    *dp_reg[DP_STATUS] &= ~DP_STATUS_FREEZE;
 
     if (dp_end_al <= dp_current_al) {
         return;


### PR DESCRIPTION
If anyone knows the history of this I would love to know.

The graphics plugin shouldn't be unsetting this bit. I am working on emulating this bit more correctly in the emulator (https://github.com/loganmc10/mupen64plus-core/commit/bbbaa26448d613b4e6c64979294807396bf817ef), and that change relys on DP_STATUS_FREEZE being left alone (like it would be on the console, it's only set/unset by writing to the DPC_STATUS_REG register).

I'm not sure how PJ64 will react to this change. It might break some Rare games like Banjo-Tooie and maybe some others, but that is because PJ64 isn't emulating that bit correctly, there are already some games that are broken because of it (Blast Corps and DK64 I believe).