### PR TITLE
Correct widescreen aspect ratio

### DIFF
--- a/core/rdp/vi.c
+++ b/core/rdp/vi.c
@@ -520,7 +520,7 @@ static void vi_process_end(void)
     }
 
     if (config.vi.widescreen) {
-        output_height = output_height * 9 / 16;
+        output_height = output_height * 3 / 4;
     }
 
     screen_upload(buffer, width, height, pitch, output_height);


### PR DESCRIPTION
Documentation on change is in the [commit message](https://github.com/ata4/angrylion-rdp-plus/commit/318278cfecf7a2f300fa3cc2c2e8f95275b0bdd9). I was able to build this in Visual Studio 2017 but the DLL file sizes are over 2MB instead of around 600KB, the Mupen64Plus version lags (might not be initiating Parallel mode?) and the Zilmar one doesn't work at all. Could you please build this yourself to double-check it's alright? (And possibly send me your versions afterward?)