### PR TITLE
cmake: Set LTO as default.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -71,7 +71,7 @@ endif(MINGW)
 
 # set IPO option, if supported
 if(ENABLE_IPO AND (CMAKE_BUILD_TYPE STREQUAL "Release"))
-    set_target_properties(alp-core PROPERTIES INTERPROCEDURAL_OPTIMIZATION ON)
+    set(CMAKE_INTERPROCEDURAL_OPTIMIZATION ON)
 endif()
 
 include_directories(${PATH_SRC})


### PR DESCRIPTION
With clang mixing LTO and non-LTO objects can lead with linker failures.

Reference:

> I found that CMAKE_INTERPROCEDURAL_OPTIMIZATION works more reliably than setting INTERPROCEDURAL_OPTIMIZATION for individual targets, and mixing targets with and without LTO does not seem to work well. With Clang, I had link errors when linking LTO-ed libraries into a non-LTO target. Also, with MSVC setting LTO for targets individually will make the linker complain about it being incompatible with incremental linking. – Alexey B.

https://stackoverflow.com/questions/31355692/cmake-support-for-gccs-link-time-optimization-lto/47370726#47370726

Fixes https://github.com/ata4/angrylion-rdp-plus/issues/83