### PR TITLE
Fix CMake error being shown in the new Android Studio release

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -92,6 +92,7 @@ endif(MINGW)
 # set IPO option, if supported
 if(ENABLE_IPO AND (CMAKE_BUILD_TYPE STREQUAL "Release"))
     set(CMAKE_INTERPROCEDURAL_OPTIMIZATION ON)
+    set(CMAKE_SHARED_LINKER_FLAGS "${CMAKE_SHARED_LINKER_FLAGS} -O3")
 endif()
 
 include_directories(${PATH_SRC})

--- a/src/core/parallel.cpp
+++ b/src/core/parallel.cpp
@@ -118,8 +118,8 @@ private:
                 m_signal_work.wait(ul, [worker_mask, this] {
                     return (m_tasks_done & worker_mask) == 0;
                 });
+            }
 #else
-
             //Busy loop wait for a bit to keep cores awake
             bool workAvailable = false;
             int count = 0;
@@ -136,7 +136,6 @@ private:
                 return (m_tasks_done & worker_mask) == 0;
             });
 #endif
-            }
         }
     }
 


### PR DESCRIPTION
The error is preventing compilation on Android. This CMake change fixes the error.

Also fix build error when Android is not defined.