### PR TITLE
mupen64plus: fix incorrect usage of API

### DIFF
--- a/src/plugin/mupen64plus/gfx_m64p.c
+++ b/src/plugin/mupen64plus/gfx_m64p.c
@@ -110,8 +110,6 @@ EXPORT m64p_error CALL PluginStartup(m64p_dynlib_handle _CoreLibHandle, void *Co
     CoreGetVersion = (ptr_PluginGetVersion)DLSYM(CoreLibHandle, "PluginGetVersion");
 
     n64video_config_init(&config);
-    vdac_init(&config);
-    screen_init(&config);
 
     ConfigSetDefaultBool(configVideoAngrylionPlus, KEY_PARALLEL, config.parallel, "Distribute rendering between multiple processors if True");
     ConfigSetDefaultInt(configVideoAngrylionPlus, KEY_NUM_WORKERS, config.num_workers, "Rendering Workers (0=Use all logical processors)");
@@ -227,6 +225,7 @@ EXPORT int CALL RomOpen (void)
     config.gfx.dp_reg = (uint32_t**)&gfx.DPC_START_REG;
 
     n64video_init(&config);
+    vdac_init(&config);
 
     return 1;
 }
@@ -234,7 +233,6 @@ EXPORT int CALL RomOpen (void)
 EXPORT void CALL RomClosed (void)
 {
     vdac_close();
-    screen_close();
     n64video_close();
 }
 


### PR DESCRIPTION
According to the docs:
https://mupen64plus.org/wiki/index.php?title=Mupen64Plus_v2.0_Core_Video_Extension

> `m64p_error VidExt_Init(void) `
> This function should be called from within the RomOpen() video plugin function call. The default SDL implementation of this function simply calls SDL_InitSubSystem(SDL_INIT_VIDEO). It does not open a rendering window or switch video modes. 

`screen_init` was being called from `PluginStartup`, `screen_init` calls `VidExt_Init`, so `screen_init` was being called too early, breaking the specification & my mupen64plus GUI, this PR moves `vdac_init` (which calls `screen_init`) to `RomOpen` which mimics the zilmar spec version and makes it work with my GUI

EDIT:
I just discovered this was caused by https://github.com/ata4/angrylion-rdp-plus/commit/5033601b0449bef16f460bd52e5b2d72c6b06556#