### PR TITLE
Fix android build again

### DIFF
--- a/src/core/parallel.cpp
+++ b/src/core/parallel.cpp
@@ -126,6 +126,7 @@ private:
                 });
             }
 #else
+            }
             //Busy loop wait for a bit to keep cores awake
             bool workAvailable = false;
             int count = 0;


### PR DESCRIPTION
Android build seems to have gotten broken again. This fixes it and nobody else should break since the change is within the Android #ifdef.