### PR TITLE
Make busyloop configurable instead of using a macro

### DIFF
--- a/src/core/n64video.c
+++ b/src/core/n64video.c
@@ -214,12 +214,8 @@ void n64video_init(struct n64video_config* _config)
     memset(&onetimewarnings, 0, sizeof(onetimewarnings));
 
     if (config.parallel) {
-        // init worker system, use busy looping for Android
-#ifdef ANDROID
-        parallel_init(config.num_workers, true);
-#else
-        parallel_init(config.num_workers, false);
-#endif
+        // init worker system, use busy looping
+        parallel_init(config.num_workers, config.busyloop);
 
         // sync states from main worker
         for (uint32_t i = 1; i < parallel_num_workers(); i++) {

--- a/src/core/n64video.h
+++ b/src/core/n64video.h
@@ -106,6 +106,7 @@ struct n64video_config
         enum dp_compat_profile compat;  // multithreading compatibility mode
     } dp;
     bool parallel;                  // use multithreaded renderer if true
+    bool busyloop;                  // use a busyloop while waiting for work
     uint32_t num_workers;           // number of rendering workers
 };
 

--- a/src/plugin/mupen64plus/gfx_m64p.c
+++ b/src/plugin/mupen64plus/gfx_m64p.c
@@ -28,6 +28,7 @@
 #define KEY_SCREEN_HEIGHT "ScreenHeight"
 #define KEY_PARALLEL "Parallel"
 #define KEY_NUM_WORKERS "NumWorkers"
+#define KEY_BUSY_LOOP "BusyLoop"
 
 #define KEY_VI_MODE "ViMode"
 #define KEY_VI_INTERP "ViInterpolation"
@@ -114,6 +115,7 @@ EXPORT m64p_error CALL PluginStartup(m64p_dynlib_handle _CoreLibHandle, void *Co
 
     ConfigSetDefaultBool(configVideoAngrylionPlus, KEY_PARALLEL, config.parallel, "Distribute rendering between multiple processors if True");
     ConfigSetDefaultInt(configVideoAngrylionPlus, KEY_NUM_WORKERS, config.num_workers, "Rendering Workers (0=Use all logical processors)");
+    ConfigSetDefaultBool(configVideoAngrylionPlus, KEY_BUSY_LOOP, config.busyloop, "Use a busyloop while waiting for work");
     ConfigSetDefaultInt(configVideoAngrylionPlus, KEY_VI_MODE, config.vi.mode, "VI mode (0=Filtered, 1=Unfiltered, 2=Depth, 3=Coverage)");
     ConfigSetDefaultInt(configVideoAngrylionPlus, KEY_VI_INTERP, config.vi.interp, "Scaling interpolation type (0=NN, 1=Linear)");
     ConfigSetDefaultBool(configVideoAngrylionPlus, KEY_VI_WIDESCREEN, config.vi.widescreen, "Use anamorphic 16:9 output mode if True");
@@ -202,6 +204,7 @@ EXPORT int CALL RomOpen (void)
 
     config.parallel = ConfigGetParamBool(configVideoAngrylionPlus, KEY_PARALLEL);
     config.num_workers = ConfigGetParamInt(configVideoAngrylionPlus, KEY_NUM_WORKERS);
+    config.busyloop = ConfigGetParamBool(configVideoAngrylionPlus, KEY_BUSY_LOOP);
     config.vi.mode = ConfigGetParamInt(configVideoAngrylionPlus, KEY_VI_MODE);
     config.vi.interp = ConfigGetParamInt(configVideoAngrylionPlus, KEY_VI_INTERP);
     config.vi.widescreen = ConfigGetParamBool(configVideoAngrylionPlus, KEY_VI_WIDESCREEN);


### PR DESCRIPTION
Make the busyloop configurable at runtime instead of using a compiler macro.