### PR TITLE
Plugin configs: Fix VI Interpolation descriptions

### DIFF
--- a/src/plugin/mupen64plus/gfx_m64p.c
+++ b/src/plugin/mupen64plus/gfx_m64p.c
@@ -117,7 +117,7 @@ EXPORT m64p_error CALL PluginStartup(m64p_dynlib_handle _CoreLibHandle, void *Co
     ConfigSetDefaultInt(configVideoAngrylionPlus, KEY_NUM_WORKERS, config.num_workers, "Rendering Workers (0=Use all logical processors)");
     ConfigSetDefaultBool(configVideoAngrylionPlus, KEY_BUSY_LOOP, config.busyloop, "Use a busyloop while waiting for work");
     ConfigSetDefaultInt(configVideoAngrylionPlus, KEY_VI_MODE, config.vi.mode, "VI mode (0=Filtered, 1=Unfiltered, 2=Depth, 3=Coverage)");
-    ConfigSetDefaultInt(configVideoAngrylionPlus, KEY_VI_INTERP, config.vi.interp, "Scaling interpolation type (0=NN, 1=Linear)");
+    ConfigSetDefaultInt(configVideoAngrylionPlus, KEY_VI_INTERP, config.vi.interp, "Scaling interpolation type (0=Blocky (Nearest-neighbor), 1=Blurry (Bilinear), 2=Soft (Bilinear + Nearest-neighbor))");
     ConfigSetDefaultBool(configVideoAngrylionPlus, KEY_VI_WIDESCREEN, config.vi.widescreen, "Use anamorphic 16:9 output mode if True");
     ConfigSetDefaultBool(configVideoAngrylionPlus, KEY_VI_HIDE_OVERSCAN, config.vi.hide_overscan, "Hide overscan area in filteded mode if True");
     ConfigSetDefaultBool(configVideoAngrylionPlus, KEY_VI_INTEGER_SCALING, config.vi.integer_scaling, "Display upscaled pixels as groups of 1x1, 2x2, 3x3, etc. if True");

--- a/src/plugin/zilmar/config.c
+++ b/src/plugin/zilmar/config.c
@@ -98,7 +98,7 @@ INT_PTR CALLBACK config_dialog_proc(HWND hwnd, UINT iMessage, WPARAM wParam, LPA
             config_dialog_fill_combo(dlg_combo_vi_mode, vi_mode_strings, VI_MODE_NUM, config.vi.mode);
 
             char* vi_interp_strings[] = {
-                "Blocky (nearest-neightbor)",   // VI_INTERP_NEAREST
+                "Blocky (nearest-neighbor)",    // VI_INTERP_NEAREST
                 "Blurry (bilinear)",            // VI_INTERP_LINEAR
                 "Soft (bilinear + NN)"          // VI_INTERP_HYBRID
             };


### PR DESCRIPTION
The description for mupen64plus wasn't up-to-date as it didn't mention the default "Soft" value. Also fixed a typo for the PJ64 setting.