### PR TITLE
cmake: git improvements

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -44,11 +44,7 @@ if(NOT CMAKE_BUILD_TYPE)
     set(CMAKE_BUILD_TYPE Release)
 endif(NOT CMAKE_BUILD_TYPE)
 
-find_package(Git REQUIRED)
-find_package(PythonInterp 3.2 REQUIRED)
-
 if (NOT ANDROID)
-    find_package(PythonLibs)
     find_package(OpenGL REQUIRED)
 endif()
 
@@ -61,7 +57,7 @@ if ( MSVC )
     set(CMAKE_CXX_FLAGS  "${CMAKE_CXX_FLAGS} /W4 /w14640 /permissive-")
 endif()
 
-set(PATH_SRC "src")
+set(PATH_SRC "${CMAKE_CURRENT_SOURCE_DIR}/src")
 
 # RDP core library
 set(PATH_CORE "${PATH_SRC}/core")
@@ -72,8 +68,9 @@ set(PATH_VERSION "${PATH_CORE}/version.h")
 add_custom_command(
     OUTPUT ${PATH_VERSION}
     COMMAND
-        ${PYTHON_EXECUTABLE}
-        "${CMAKE_SOURCE_DIR}/make_version.py"
+        ${CMAKE_COMMAND} -DPATH_VERSION=${PATH_VERSION}
+        -DSOURCE_DIR=${CMAKE_CURRENT_SOURCE_DIR}
+        -P ${CMAKE_CURRENT_SOURCE_DIR}/git-version.cmake
     COMMENT "Generate Git version"
 )
 

--- a/git-version.cmake
+++ b/git-version.cmake
@@ -1,0 +1,55 @@
+set(GIT_BRANCH "unknown")
+set(GIT_COMMIT_DATE "unknown")
+set(GIT_COMMIT_HASH "unknown")
+set(GIT_TAG "unknown")
+
+find_package(Git)
+if(GIT_FOUND AND EXISTS "${SOURCE_DIR}/.git/")
+	execute_process(
+		COMMAND ${GIT_EXECUTABLE} rev-parse --abbrev-ref HEAD
+		WORKING_DIRECTORY ${SOURCE_DIR}
+		RESULT_VARIABLE GIT_BRANCH_RESULT
+		OUTPUT_VARIABLE GIT_BRANCH
+		OUTPUT_STRIP_TRAILING_WHITESPACE
+	)
+	if(NOT ${GIT_BRANCH_RESULT} EQUAL 0)
+		message(WARNING "git rev-parse failed, unknown branch.")
+	endif()
+
+	execute_process(
+		COMMAND ${GIT_EXECUTABLE} show -s --format=%cs
+		WORKING_DIRECTORY ${SOURCE_DIR}
+		RESULT_VARIABLE GIT_COMMIT_DATE_RESULT
+		OUTPUT_VARIABLE GIT_COMMIT_DATE
+		OUTPUT_STRIP_TRAILING_WHITESPACE
+	)
+	if(NOT ${GIT_COMMIT_DATE_RESULT} EQUAL 0)
+		message(WARNING "git show failed, unknown commit date.")
+	endif()
+
+	execute_process(
+		COMMAND ${GIT_EXECUTABLE} show -s --format=%h
+		WORKING_DIRECTORY ${SOURCE_DIR}
+		RESULT_VARIABLE GIT_COMMIT_HASH_RESULT
+		OUTPUT_VARIABLE GIT_COMMIT_HASH
+		OUTPUT_STRIP_TRAILING_WHITESPACE
+	)
+	if(NOT ${GIT_COMMIT_HASH_RESULT} EQUAL 0)
+		message(WARNING "git show failed, unknown commit hash.")
+	endif()
+
+	execute_process(
+		COMMAND ${GIT_EXECUTABLE} describe --dirty --always --tags
+		WORKING_DIRECTORY ${SOURCE_DIR}
+		RESULT_VARIABLE GIT_TAG_RESULT
+		OUTPUT_VARIABLE GIT_TAG
+		OUTPUT_STRIP_TRAILING_WHITESPACE
+	)
+	if(NOT ${GIT_TAG_RESULT} EQUAL 0)
+		message(WARNING "git describe failed, unknown tag.")
+	endif()
+else()
+	message(WARNING "git not found or not a git repo.")
+endif()
+
+configure_file(${PATH_VERSION}.in ${PATH_VERSION} @ONLY)


### PR DESCRIPTION
This PR does the following:

* Removes the dependency on python3
* Allows git to be an optional dependency
* Executes git in the correct directory
* Doesn't execute git when there is no .git directory

Caveat:

The `GIT_TAG` format changes, it doesn't seem trivial to remove the git commit hash from the git tag.

* Before: `v1.6-5` or `v1.6-5-dirty`
* Now: `v1.6-5-g1145315` or `v1.6-5-g1145315-dirty`

Alternatively I could drop the number of commits since the last tag with `--abbrev=0`.

* Example: `v1.6` or `v1.6-dirty`

Maybe someone better with cmake could replicate what the python script is doing?