### PR TITLE
Fix cmake compatibility warning

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.22)
+cmake_minimum_required(VERSION 3.9)
 
 option(BUILD_MUPEN64PLUS "Enables build of mupen64plus version" ON)
 option(BUILD_PROJECT64   "Enables build of project64 version" WIN32)

--- a/src/core/parallel.cpp
+++ b/src/core/parallel.cpp
@@ -8,6 +8,7 @@
 #include <mutex>
 #include <thread>
 #include <vector>
+#include <stdexcept>
 
 class Parallel
 {


### PR DESCRIPTION
This PR fixes the following:
```
Make Deprecation Warning at CMakeLists.txt:1 (cmake_minimum_required):
  Compatibility with CMake < 3.5 will be removed from a future version of
  CMake.

  Update the VERSION argument <min> value or use a ...<max> suffix to tell
  CMake that the project does not need compatibility with older versions.
```

and it fixes the following compilation error by including `stdexcept` to `parallel.cpp`:
```
[ 45%] Building CXX object CMakeFiles/alp-core.dir/src/core/parallel.cpp.o
/home/rosalie/dev/angrylion-rdp-plus/angrylion-rdp-plus/src/core/parallel.cpp: In member function ‘void Parallel::run(std::function<void(unsigned int)>&&)’:
/home/rosalie/dev/angrylion-rdp-plus/angrylion-rdp-plus/src/core/parallel.cpp:73:24: error: ‘runtime_error’ is not a member of ‘std’
   73 |             throw std::runtime_error("Workers are exiting and no longer accept work");
      |                        ^~~~~~~~~~~~~
/home/rosalie/dev/angrylion-rdp-plus/angrylion-rdp-plus/src/core/parallel.cpp:11:1: note: ‘std::runtime_error’ is defined in header ‘<stdexcept>’; did you forget to ‘#include <stdexcept>’?
   10 | #include <vector>
  +++ |+#include <stdexcept>
   11 | 
make[2]: *** [CMakeFiles/alp-core.dir/build.make:94: CMakeFiles/alp-core.dir/src/core/parallel.cpp.o] Error 1
make[2]: *** Waiting for unfinished jobs....
```