### PR TITLE
Bump minimum CMake version

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.9)
+cmake_minimum_required(VERSION 3.10)
 
 option(BUILD_MUPEN64PLUS "Enables build of mupen64plus version" ON)
 option(BUILD_PROJECT64   "Enables build of project64 version" WIN32)


### PR DESCRIPTION
Silences the deprecation warning.
See https://cmake.org/cmake/help/latest/command/cmake_minimum_required.html.